### PR TITLE
Append path to the beginning instead of at the end

### DIFF
--- a/CustomPATH.py
+++ b/CustomPATH.py
@@ -14,7 +14,7 @@ def plugin_loaded():
             if override:
                 os.environ['PATH'] = path
             else:
-                os.environ['PATH'] += os.pathsep+path
+                os.environ['PATH'] = path+os.pathsep+os.environ['PATH']
             print('Path loaded: %s' % os.environ['PATH'])
         else:
             print('Path loaded: %s' % os.environ['PATH'])


### PR DESCRIPTION
This enables you to add paths that take preceedence.
This is required for things like .rbenv to take preceedence over system ruby for example.
