### PR TITLE
add append_front option

### DIFF
--- a/CustomPATH.py
+++ b/CustomPATH.py
@@ -14,7 +14,11 @@ def plugin_loaded():
             if override:
                 os.environ['PATH'] = path
             else:
-                os.environ['PATH'] += os.pathsep+path
+                append_front = settings.get('append_front')
+                if append_front:
+                    os.environ['PATH'] = path + os.pathsep + os.environ['PATH']
+                else:
+                    os.environ['PATH'] += os.pathsep + path
             print('Path loaded: %s' % os.environ['PATH'])
         else:
             print('Path loaded: %s' % os.environ['PATH'])

--- a/CustomPATH.sublime-settings
+++ b/CustomPATH.sublime-settings
@@ -1,4 +1,5 @@
 {
     "override": false,
+    "append_front": false,
     "PATH":"/opt/node_moduler/bin/"
 }


### PR DESCRIPTION
I was about to write almost the exact same plugin when I found yours :)

However, like @chav02 suggested in PR #1, I need to append the path to the front. I think it's more common to append the path at the front. For example the system provides git, but one may have a newer version installed in `/usr/local/bin`.

I added the `"append_front"` option as you suggested.